### PR TITLE
A few ideas where to look for a CORS configuration improvements

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,8 @@ Rails.application.configure do
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
   # config.action_cable.url = 'wss://example.com/cable'
-  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+  # No idea what Action Cable is, but there's a slight chance this may add Access-Control-Allow-Origin: '*' to the response
+  config.action_cable.allowed_request_origins = ['*']
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -2,4 +2,4 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
 const environment = require('./environment')
 
-module.exports = environment.toWebpackConfig()
+module.exports = Object.assign({}, environment.toWebpackConfig(), {devServer: {allowedHosts: ['*', ], },});

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -82,6 +82,11 @@ test:
 production:
   <<: *default
 
+  # dev_server does not probably fit production, but it's a starting point
+  dev_server:
+    headers:
+      'Access-Control-Allow-Origin': '*'
+
   # Production depends on precompilation of packs prior to booting for performance.
   compile: false
 


### PR DESCRIPTION
I've edited a few places that might be responsible for handling CORS response headers. I have no experience in Ruby or hosting on Heroku, but I believe theese may be a good starting points in looking for a resolution.

When trying to GET data from your endpoint from JS at localhost:port, the browser sends OPTIONS request to your backend first.
Your backend needs to respond to OPTIONS method with a header 'Access-Control-Allow-Origin' : '*' (pro tip: never use '*' in production!).
If response to OPTIONS method does not specify '*' or 'localhost:port' specifically, the browser assumes that your backend DOES NOT ALLOW to call GET from another domain than the one where you host the backend.